### PR TITLE
Use DirectX Shader Compiler instead of shaderc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,7 @@
 	path = extern/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
 	branch = sdk-1.3.236
-[submodule "extern/shaderc"]
-	path = extern/shaderc
-	url = https://github.com/google/shaderc.git
-	branch = main
+[submodule "extern/dxc"]
+        path = extern/dxc
+        url = https://github.com/microsoft/DirectXShaderCompiler.git
+        branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Git REQUIRED)
 include(CMakeDREHelpers.txt)
 update_git_submodule(assimp)
 update_git_submodule(glm)
-update_git_submodule(shaderc)
+update_git_submodule(directxshadercompiler)
 update_git_submodule(glTF-Sample-Models)
 update_git_submodule(imgui)
 update_git_submodule(SPIRV-Cross)
@@ -25,22 +25,17 @@ option(BUILD_STATIC_LIBS "Build package with shared libraries." ON) # this one i
 option(ASSIMP_BUILD_ZLIB "Build your own zlib" ON)
 option(ASSIMP_BUILD_TESTS "If the test suite for Assimp is built in addition to the library." OFF)
 option(ASSIMP_INSTALL "Disable this if you want to use assimp as a submodule." ON)
-option(SHADERC_ENABLE_SHARED_CRT "Use the shared CRT instead of the static CRT" ON)
 #==========
 add_subdirectory(extern/assimp)
 
-
-#override shaderc defaults
+#override dxc defaults
 #==========
-option(SHADERC_SKIP_INSTALL ON)
-option(SHADERC_SKIP_TESTS "Skip building tests" ON)
-option(SHADERC_SKIP_EXAMPLES "Skip building examples" ON)
-option(SHADERC_SKIP_COPYRIGHT_CHECK "Skip copyright check" ON)
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
-execute_process(COMMAND python extern/shaderc/utils/git-sync-deps)
+option(ENABLE_SPIRV_CODEGEN "Enable SPIR-V CodeGen in DXC" ON)
+option(LLVM_INCLUDE_TESTS "Build LLVM tests" OFF)
+option(LLVM_INCLUDE_EXAMPLES "Build LLVM examples" OFF)
+option(HLSL_INCLUDE_TESTS "Build HLSL tests" OFF)
 #==========
-add_subdirectory(extern/shaderc)
-
+add_subdirectory(extern/dxc)
 
 add_subdirectory(extern/glm)
 add_subdirectory(extern/Vulkan-Headers)

--- a/include/engine/io/IOManager.hpp
+++ b/include/engine/io/IOManager.hpp
@@ -106,7 +106,6 @@ public:
     static void             WriteNewFile(char const* path, DRE::ByteBuffer const& buffer);
 
     DRE::ByteBuffer         CompileGLSL(char const* file);
-    std::mutex&             GetShaderIncluderMutex() { return m_ShaderIncluderMutex; }
 
     inline bool                             NewShadersPending() { return IOManager::m_PendingChangesFlag.load(std::memory_order::acquire); }
     DRE::InplaceVector<DRE::String64, 12>   GetPendingShaders();
@@ -139,7 +138,6 @@ private:
 
     DRE::HashTable<DRE::String64, ShaderData, DRE::AllocatorLinear> m_ShaderData;
 
-    std::mutex  m_ShaderIncluderMutex;
 
     DRE::InplaceVector<DRE::String64, 12> m_PendingShaders;
     std::mutex  m_PendingShadersMutex;

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(engine PUBLIC
 target_compile_features(engine PUBLIC cxx_std_20)
 target_compile_definitions(engine PUBLIC WIN32_LEAN_AND_MEAN NOMINMAX)
 
-target_link_libraries(engine PUBLIC foundation vk_wrapper assimp glm_static imgui stb_image spirv-cross-cpp spirv-cross-reflect shaderc)
+target_link_libraries(engine PUBLIC foundation vk_wrapper assimp glm_static imgui stb_image spirv-cross-cpp spirv-cross-reflect dxcompiler dxil)
 
 source_group(
 	TREE "${DRE_SOURCE_DIR}/include/engine"

--- a/src/engine/io/IOManager.cpp
+++ b/src/engine/io/IOManager.cpp
@@ -7,6 +7,7 @@
 #include <charconv>
 #include <filesystem>
 #include <future>
+#include <string>
 
 #include <foundation\memory\Memory.hpp>
 #include <foundation\memory\ByteBuffer.hpp>
@@ -27,7 +28,9 @@
 #include <engine\scene\Scene.hpp>
 
 #include <spirv_cross.hpp>
-#include <shaderc\shaderc.hpp>
+#include <dxc/dxcapi.h>
+#include <wrl.h>
+#include <vector>
 
 namespace IO
 {
@@ -116,122 +119,86 @@ void IOManager::WriteNewFile(char const* path, DRE::ByteBuffer const& buffer)
     ostream.close();
 }
 
-struct DREIncludeData
-{
-    DRE::ByteBuffer content;
-    DRE::String64 contentName;
-    DRE::String64 targetName;
-};
-
-class DREIncluder : public shaderc::CompileOptions::IncluderInterface
-{
-public:
-    DREIncluder(IOManager* manager)
-        : m_IOManager{ manager }
-    {}
-
-    virtual shaderc_include_result* GetInclude(const char* requested_source,
-        shaderc_include_type type,
-        const char* requesting_source,
-        size_t include_depth) override
-    {
-        std::mutex& m = m_IOManager->GetShaderIncluderMutex();
-        m.lock();
-        shaderc_include_result* result = DRE::g_FrameScratchAllocator.Alloc<shaderc_include_result>();
-        DREIncludeData* data = DRE::g_FrameScratchAllocator.Alloc<DREIncludeData>();
-        m.unlock();
-
-        data->contentName = "shaders\\";
-        data->contentName.Append(requested_source);
-
-        data->targetName = requesting_source;
-        
-        std::uint64_t const bytesRead = IOManager::ReadFileToBuffer(data->contentName.GetData(), &data->content);
-        DRE_ASSERT(bytesRead != 0, "Failed to read requested include for GLSL.");
-
-        result->source_name = data->contentName.GetData();
-        result->content_length = data->content.Size();
-        result->content = data->content.As<char*>();
-        result->source_name = data->targetName.GetData();
-        result->source_name_length = data->targetName.GetSize();
-        result->user_data = data;
-
-        return result;
-    }
-
-    // Handles shaderc_include_result_release_fn callbacks.
-    virtual void ReleaseInclude(shaderc_include_result* result) override
-    {
-        DREIncludeData* data = (DREIncludeData*)result->user_data;
-        data->~DREIncludeData();
-    }
-
-    virtual ~DREIncluder() = default;
-
-private:
-    IOManager* m_IOManager;
-};
 
 DRE::ByteBuffer IOManager::CompileGLSL(char const* path)
 {
-    std::filesystem::path filePath{ path };
+    using Microsoft::WRL::ComPtr;
 
+    std::filesystem::path filePath{ path };
     std::cout << "Compiling shader " << path << std::endl;
 
-    shaderc_shader_kind kind = (shaderc_shader_kind)0;
+    DRE::ByteBuffer sourceBlob{};
+    std::uint64_t const bytesRead = ReadFileToBuffer(path, &sourceBlob);
+    DRE_ASSERT(bytesRead != 0, "Failed to read HLSL source.");
 
-    shaderc::Compiler compiler;
-    shaderc::CompileOptions options;
-    options.SetTargetEnvironment(shaderc_target_env::shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_3);
-    options.SetIncluder(std::make_unique<DREIncluder>(this));
+    ComPtr<IDxcUtils> utils;
+    ComPtr<IDxcCompiler3> compiler;
+    DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&utils));
+    DxcCreateInstance(CLSID_DxcCompiler, IID_PPV_ARGS(&compiler));
+
+    DxcBuffer source{};
+    source.Ptr = sourceBlob.Data();
+    source.Size = sourceBlob.Size();
+    source.Encoding = DXC_CP_UTF8;
+    std::wstring wpath = filePath.wstring();
+    source.Name = wpath.c_str();
+
+    std::vector<LPCWSTR> arguments;
+    arguments.push_back(L"-E"); arguments.push_back(L"main");
+    arguments.push_back(L"-spirv");
+    arguments.push_back(L"-fspv-target-env=vulkan1.3");
+    arguments.push_back(L"-Ishaders");
 
     auto extension = filePath.extension();
     if (extension == ".vert")
     {
-        kind = shaderc_glsl_vertex_shader;
-        options.AddMacroDefinition("DRE_VERTEX_SHADER", "1");
+        arguments.push_back(L"-T"); arguments.push_back(L"vs_6_7");
+        arguments.push_back(L"-DDRE_VERTEX_SHADER=1");
     }
     else if (extension == ".frag")
     {
-        kind = shaderc_glsl_fragment_shader;
-        options.AddMacroDefinition("DRE_FRAGMENT_SHADER", "1");
+        arguments.push_back(L"-T"); arguments.push_back(L"ps_6_7");
+        arguments.push_back(L"-DDRE_FRAGMENT_SHADER=1");
     }
     else if (extension == ".comp")
     {
-        kind = shaderc_glsl_compute_shader;
-        options.AddMacroDefinition("DRE_COMPUTE_SHADER", "1");
+        arguments.push_back(L"-T"); arguments.push_back(L"cs_6_7");
+        arguments.push_back(L"-DDRE_COMPUTE_SHADER=1");
     }
     else
-        DRE_ASSERT(false, "Attempt to compile unsupported shader type. See file extension.");
-
-    DRE::ByteBuffer sourceBlob{};
-    std::uint64_t const bytesRead = ReadFileToBuffer(path, &sourceBlob);
-    DRE_ASSERT(bytesRead != 0, "Failed to read GLSL source.");
-
-    shaderc::PreprocessedSourceCompilationResult preprocess = compiler.PreprocessGlsl(sourceBlob.As<char*>(), sourceBlob.Size(), kind, path, options);
-    if (preprocess.GetCompilationStatus() != shaderc_compilation_status_success)
     {
-        std::cout << preprocess.GetErrorMessage();
-        return DRE::ByteBuffer{};
+        DRE_ASSERT(false, "Attempt to compile unsupported shader type. See file extension.");
     }
 
-    DRE::U64 const preprocessedSize = DRE::PtrDifference(preprocess.end(), preprocess.begin());
-    shaderc::SpvCompilationResult compile = compiler.CompileGlslToSpv(preprocess.begin(), preprocessedSize, kind, path, "main", options);
+    ComPtr<IDxcIncludeHandler> includer;
+    utils->CreateDefaultIncludeHandler(&includer);
 
-    if (compile.GetCompilationStatus() != shaderc_compilation_status_success) 
+    ComPtr<IDxcResult> result;
+    HRESULT hr = compiler->Compile(&source, arguments.data(), static_cast<UINT32>(arguments.size()), includer.Get(), IID_PPV_ARGS(&result));
+    if (FAILED(hr))
+    {
+        return {};
+    }
+
+    ComPtr<IDxcBlobUtf8> errors;
+    result->GetOutput(DXC_OUT_ERRORS, IID_PPV_ARGS(&errors), nullptr);
+    if (errors && errors->GetStringLength() > 0)
     {
 #ifdef DEBUG_SHADER_COMPILATION
         std::lock_guard<std::mutex> lock{ m_DebugShaderCompilationMutex };
-        std::cout << "FAILED COMPILING SHADER " << filePath << std::endl << "SOURCE: " << std::endl;
-        std::cout << preprocess.begin();
 #endif
-        std::cout << compile.GetErrorMessage();
-
-        return DRE::ByteBuffer{};
+        std::cout << errors->GetStringPointer() << std::endl;
     }
 
-    DRE::U64 const moduleSize = DRE::PtrDifference(compile.end(), compile.begin());
-    return DRE::ByteBuffer{ (void*)compile.begin(), moduleSize };
+    result->GetStatus(&hr);
+    if (FAILED(hr))
+    {
+        return {};
+    }
+
+    ComPtr<IDxcBlob> shader;
+    result->GetOutput(DXC_OUT_OBJECT, IID_PPV_ARGS(&shader), nullptr);
+    return DRE::ByteBuffer{ shader->GetBufferPointer(), shader->GetBufferSize() };
 }
 
 DRE::InplaceVector<DRE::String64, 12> IOManager::GetPendingShaders()


### PR DESCRIPTION
## Summary
- replace shaderc with DirectXShaderCompiler submodule and build options
- link engine against dxcompiler and dxil
- compile shaders using DXC API instead of shaderc

## Testing
- `cmake -S . -B build` *(fails: unable to clone submodules due to network/403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea715938832f94b951aa43897f41