### PR TITLE
Fix indentation for rendering settings editor entries

### DIFF
--- a/include/editor/BaseEditor.hpp
+++ b/include/editor/BaseEditor.hpp
@@ -29,6 +29,7 @@ public:
         SceneGraph,
         Stats,
         TextureInspector,
+        RenderingSettings,
         MAX
     };
 

--- a/include/editor/RenderingSettingsEditor.hpp
+++ b/include/editor/RenderingSettingsEditor.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <editor\BaseEditor.hpp>
+
+namespace EDITOR
+{
+
+class RenderingSettingsEditor : public BaseEditor
+{
+public:
+    RenderingSettingsEditor(BaseEditor* rootEditor, EditorFlags flags);
+    RenderingSettingsEditor(RenderingSettingsEditor&& rhs);
+
+    RenderingSettingsEditor& operator=(RenderingSettingsEditor&& rhs);
+
+    virtual ~RenderingSettingsEditor() {}
+
+    virtual BaseEditor::Type GetType() const override { return BaseEditor::Type::RenderingSettings; }
+
+    virtual void Render() override;
+};
+
+}

--- a/src/editor/CMakeLists.txt
+++ b/src/editor/CMakeLists.txt
@@ -6,7 +6,8 @@ set(EDITOR_HEADER_LIST
 	"${DRE_SOURCE_DIR}/include/editor/RootEditor.hpp"
 	"${DRE_SOURCE_DIR}/include/editor/SceneGraphEditor.hpp"
 	"${DRE_SOURCE_DIR}/include/editor/StatsEditor.hpp"
-	"${DRE_SOURCE_DIR}/include/editor/TextureInspector.hpp")
+	"${DRE_SOURCE_DIR}/include/editor/TextureInspector.hpp"
+	"${DRE_SOURCE_DIR}/include/editor/RenderingSettingsEditor.hpp")
 
 set(EDITOR_SOURCE_LIST
 	"${DRE_SOURCE_DIR}/src/editor/ViewportInputManager.cpp"
@@ -16,7 +17,8 @@ set(EDITOR_SOURCE_LIST
 	"${DRE_SOURCE_DIR}/src/editor/RootEditor.cpp"
 	"${DRE_SOURCE_DIR}/src/editor/SceneGraphEditor.cpp"
 	"${DRE_SOURCE_DIR}/src/editor/StatsEditor.cpp"
-	"${DRE_SOURCE_DIR}/src/editor/TextureInspector.cpp")
+	"${DRE_SOURCE_DIR}/src/editor/TextureInspector.cpp"
+	"${DRE_SOURCE_DIR}/src/editor/RenderingSettingsEditor.cpp")
 	
 add_library(editor STATIC ${EDITOR_HEADER_LIST} ${EDITOR_SOURCE_LIST})
 

--- a/src/editor/RenderingSettingsEditor.cpp
+++ b/src/editor/RenderingSettingsEditor.cpp
@@ -1,0 +1,87 @@
+#include <editor\RenderingSettingsEditor.hpp>
+
+#include <editor\RootEditor.hpp>
+#include <foundation\Common.hpp>
+#include <gfx\GraphicsManager.hpp>
+#include <engine\ApplicationContext.hpp>
+
+#include <imgui.h>
+
+namespace EDITOR
+{
+
+RenderingSettingsEditor::RenderingSettingsEditor(BaseEditor* rootEditor, EditorFlags flags)
+    : BaseEditor{ rootEditor, flags }
+{}
+
+RenderingSettingsEditor::RenderingSettingsEditor(RenderingSettingsEditor&& rhs)
+    : BaseEditor{ DRE_MOVE(rhs) }
+{
+    operator=(DRE_MOVE(rhs));
+}
+
+RenderingSettingsEditor& RenderingSettingsEditor::operator=(RenderingSettingsEditor&& rhs)
+{
+    BaseEditor::operator=(DRE_MOVE(rhs));
+
+    return *this;
+}
+
+void RenderingSettingsEditor::Render()
+{
+    bool isOpen = true;
+    if (ImGui::Begin("Rendering Settings", &isOpen))
+    {
+        if (GFX::g_GraphicsManager != nullptr)
+        {
+            GFX::GraphicsSettings& settings = GFX::g_GraphicsManager->GetGraphicsSettings();
+
+            ImGui::Checkbox("Use ACES", &settings.m_UseACESEncoding);
+            ImGui::SliderFloat("Exposure target EV", &settings.m_ExposureEV, -3.0f, 5.0f);
+
+            if (ImGui::Button("Enable TAA"))
+            {
+                settings.m_AlphaTAA = 0.9f;
+                settings.m_JitterScale = 0.35f;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Disable TAA"))
+            {
+                settings.m_AlphaTAA = 0.0f;
+                settings.m_JitterScale = 0.0f;
+            }
+
+            ImGui::SliderFloat("TAA Alpha", &settings.m_AlphaTAA, 0.0f, 1.0f);
+            ImGui::SliderFloat("TAA Jitter Scale", &settings.m_JitterScale, 0.0f, 2.0f);
+            ImGui::SliderFloat("TAA Variance Gamma", &settings.m_VarianceGammaTAA, 0.0f, 5.0f);
+
+            ImGui::Checkbox("Pause time", &DRE::g_AppContext.m_PauseTime);
+
+            ImGui::SliderFloat("Generic Scalar", &settings.m_GenericScalar, -2.0f, 2.0f);
+
+            ImGui::Separator();
+            ImGui::TextUnformatted("Water settings");
+
+            ImGui::Checkbox("Water wireframe", &settings.m_WaterWireframe);
+            ImGui::Checkbox("FFT Water", &settings.m_UseFFTWater);
+            ImGui::SliderFloat("Water speed", &settings.m_WaterSpeed, 0.0f, 3.0f);
+            ImGui::SliderFloat("Water size meters", &settings.m_WaterSizeMeters, 1.0f, 100.0f);
+            ImGui::SliderFloat("Water amplitude", &settings.m_WaterAmplitude, 0.0f, 1000.0f);
+            ImGui::SliderFloat("Water wind dir X", &settings.m_WindDirectionX, -1.0f, 1.0f);
+            ImGui::SliderFloat("Water wind speed", &settings.m_WindSpeed, 0.0f, 100.0f);
+            ImGui::SliderFloat("Water wind dir factor", &settings.m_WindDirFactor, 0.0f, 100.0f);
+        }
+        else
+        {
+            ImGui::TextUnformatted("Graphics manager unavailable.");
+        }
+    }
+    ImGui::End();
+
+    if (!isOpen)
+    {
+        Close();
+    }
+}
+
+}

--- a/src/editor/RenderingSettingsEditor.cpp
+++ b/src/editor/RenderingSettingsEditor.cpp
@@ -32,14 +32,19 @@ void RenderingSettingsEditor::Render()
     bool isOpen = true;
     if (ImGui::Begin("Rendering Settings", &isOpen))
     {
-        if (GFX::g_GraphicsManager != nullptr)
+        GFX::GraphicsManager* graphicsManager = GFX::g_GraphicsManager;
+        if (graphicsManager != nullptr)
         {
-            GFX::GraphicsSettings& settings = GFX::g_GraphicsManager->GetGraphicsSettings();
+            GFX::GraphicsSettings& settings = graphicsManager->GetGraphicsSettings();
 
+            ImGui::TextUnformatted("Tone mapping");
+            ImGui::Separator();
             ImGui::Checkbox("Use ACES", &settings.m_UseACESEncoding);
             ImGui::SliderFloat("Exposure target EV", &settings.m_ExposureEV, -3.0f, 5.0f);
 
-            if (ImGui::Button("Enable TAA"))
+            ImGui::Separator();
+            ImGui::TextUnformatted("Temporal AA");
+            if (ImGui::Button("Enable TAA defaults"))
             {
                 settings.m_AlphaTAA = 0.9f;
                 settings.m_JitterScale = 0.35f;
@@ -50,18 +55,20 @@ void RenderingSettingsEditor::Render()
                 settings.m_AlphaTAA = 0.0f;
                 settings.m_JitterScale = 0.0f;
             }
-
             ImGui::SliderFloat("TAA Alpha", &settings.m_AlphaTAA, 0.0f, 1.0f);
             ImGui::SliderFloat("TAA Jitter Scale", &settings.m_JitterScale, 0.0f, 2.0f);
             ImGui::SliderFloat("TAA Variance Gamma", &settings.m_VarianceGammaTAA, 0.0f, 5.0f);
 
+            ImGui::Separator();
+            ImGui::TextUnformatted("Timing");
             ImGui::Checkbox("Pause time", &DRE::g_AppContext.m_PauseTime);
 
+            ImGui::Separator();
+            ImGui::TextUnformatted("Misc");
             ImGui::SliderFloat("Generic Scalar", &settings.m_GenericScalar, -2.0f, 2.0f);
 
             ImGui::Separator();
-            ImGui::TextUnformatted("Water settings");
-
+            ImGui::TextUnformatted("Water");
             ImGui::Checkbox("Water wireframe", &settings.m_WaterWireframe);
             ImGui::Checkbox("FFT Water", &settings.m_UseFFTWater);
             ImGui::SliderFloat("Water speed", &settings.m_WaterSpeed, 0.0f, 3.0f);

--- a/src/editor/RootEditor.cpp
+++ b/src/editor/RootEditor.cpp
@@ -4,6 +4,7 @@
 #include <engine\scene\Camera.hpp>
 #include <engine\scene\Scene.hpp>
 #include <editor\CameraEditor.hpp>
+#include <editor\RenderingSettingsEditor.hpp>
 #include <editor\SceneGraphEditor.hpp>
 #include <editor\StatsEditor.hpp>
 #include <editor\TextureInspector.hpp>
@@ -72,6 +73,15 @@ void RootEditor::Render()
             {
                 StatsEditor* statsEditor = DRE::g_MainAllocator.Alloc<StatsEditor>(this, EDITOR_FLAGS_NONE);
                 m_Editors.EmplaceBack(statsEditor);
+            }
+        }
+
+        if (ImGui::MenuItem("Rendering Settings"))
+        {
+            if (GetEditorByType(BaseEditor::Type::RenderingSettings) == nullptr)
+            {
+                RenderingSettingsEditor* renderingEditor = DRE::g_MainAllocator.Alloc<RenderingSettingsEditor>(this, EDITOR_FLAGS_NONE);
+                m_Editors.EmplaceBack(renderingEditor);
             }
         }
 


### PR DESCRIPTION
## Summary
- restore tab indentation for the rendering settings editor additions in src/editor/CMakeLists.txt
- ensure the CMake file retains its trailing newline for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4c2be6e14832f843f8ccf86db550b