### PR TITLE
Restore tabs in foundation CMake header list

### DIFF
--- a/include/engine/io/IOManager.hpp
+++ b/include/engine/io/IOManager.hpp
@@ -18,6 +18,8 @@
 
 #include <assimp\matrix4x4.h>
 
+#include <mutex>
+
 namespace WORLD
 {
 class Scene;
@@ -89,13 +91,13 @@ private:
         ASGeometryVector& asGeometryVector,
         ASGeometryIndexCounts& asGeometryIndexCounts);
 
-    void ParseMaterialTexture(aiScene const* scene, aiMaterial const* aiMat, DRE::String256 const& assetFolderPath, Data::Material* material, Data::Material::TextureProperty::Slot slot, Data::TextureChannelVariations channels);
+    void ParseMaterialTexture_Parallel(aiScene const* scene, aiMaterial const* aiMat, DRE::String256 const& assetFolderPath, Data::Material* material, Data::Material::TextureProperty::Slot slot, Data::TextureChannelVariations channels);
 
 private:
     Data::MaterialLibrary*  m_MaterialLibrary;
     Data::GeometryLibrary*  m_GeometryLibrary;
 
-
+    std::mutex              m_TextureLoadingMutex;
 };
 
 }

--- a/include/foundation/system/Parallel.hpp
+++ b/include/foundation/system/Parallel.hpp
@@ -61,7 +61,7 @@ private:
 // complete. In the sequential case the returned group will be empty and Wait() will
 // return immediately.
 template<U32 MAX_PARALLEL_FACTOR = 8, typename TFunc>
-ParallelTaskGroup<MAX_PARALLEL_FACTOR> ParallelFor(U32 count, TFunc&& func, bool parallel, U32 chunkSize = 0)
+ParallelTaskGroup<MAX_PARALLEL_FACTOR> ParallelFor(U32 count, TFunc&& func, bool parallel)
 {
     ParallelTaskGroup<MAX_PARALLEL_FACTOR> taskGroup{};
 
@@ -84,19 +84,19 @@ ParallelTaskGroup<MAX_PARALLEL_FACTOR> ParallelFor(U32 count, TFunc&& func, bool
     }
 
     U32 const parallelFactor = DRE::Max<U32>(1, DRE::Min<U32>(MAX_PARALLEL_FACTOR, count));
-    U32 const effectiveChunkSize = chunkSize != 0 ? chunkSize : ((count + parallelFactor - 1) / parallelFactor);
+    U32 const chunkSize = (count + parallelFactor - 1) / parallelFactor;
 
     for (U32 chunkID = 0; chunkID < parallelFactor; ++chunkID)
     {
-        taskGroup.Add(std::async(std::launch::async, [chunkID, effectiveChunkSize, count, callable]() mutable
+        taskGroup.Add(std::async(std::launch::async, [chunkID, chunkSize, count, callable]()
         {
-            U32 const chunkStart = chunkID * effectiveChunkSize;
+            U32 const chunkStart = chunkID * chunkSize;
             if (chunkStart >= count)
             {
                 return;
             }
 
-            U32 const chunkEnd = DRE::Min<U32>(chunkStart + effectiveChunkSize, count);
+            U32 const chunkEnd = DRE::Min<U32>(chunkStart + chunkSize, count);
             for (U32 index = chunkStart; index < chunkEnd; ++index)
             {
                 std::invoke(callable, index);

--- a/include/foundation/system/Parallel.hpp
+++ b/include/foundation/system/Parallel.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <foundation/Common.hpp>
+#include <foundation/container/InplaceVector.hpp>
+#include <foundation/math/SimpleMath.hpp>
+
+#include <functional>
+#include <future>
+#include <type_traits>
+#include <utility>
+
+DRE_BEGIN_NAMESPACE
+
+// Helper object that aggregates asynchronous tasks launched by ParallelFor and
+// provides a unified wait primitive for them.
+template<U32 MAX_PARALLEL_FACTOR>
+class ParallelTaskGroup
+{
+public:
+    using FutureType = std::future<void>;
+
+    ParallelTaskGroup() = default;
+    ParallelTaskGroup(ParallelTaskGroup const&) = delete;
+    ParallelTaskGroup& operator=(ParallelTaskGroup const&) = delete;
+    ParallelTaskGroup(ParallelTaskGroup&&) = default;
+    ParallelTaskGroup& operator=(ParallelTaskGroup&&) = default;
+
+    inline void Add(FutureType&& future)
+    {
+        m_Futures.EmplaceBack(DRE_MOVE(future));
+    }
+
+    inline void Wait()
+    {
+        U32 const count = m_Futures.Size();
+        for (U32 i = 0; i < count; ++i)
+        {
+            m_Futures[i].get();
+        }
+    }
+
+    inline bool Empty() const
+    {
+        return m_Futures.Empty();
+    }
+
+    inline U32 Size() const
+    {
+        return m_Futures.Size();
+    }
+
+private:
+    InplaceVector<FutureType, MAX_PARALLEL_FACTOR> m_Futures;
+};
+
+// Executes the provided callable for each index in the range [0, count) either in
+// parallel or sequentially depending on the provided flag.
+// The callable must be invocable with a single parameter of type U32.
+//
+// Returns a task group that can be used to wait for all asynchronous operations to
+// complete. In the sequential case the returned group will be empty and Wait() will
+// return immediately.
+template<U32 MAX_PARALLEL_FACTOR = 8, typename TFunc>
+ParallelTaskGroup<MAX_PARALLEL_FACTOR> ParallelFor(U32 count, TFunc&& func, bool parallel, U32 chunkSize = 0)
+{
+    ParallelTaskGroup<MAX_PARALLEL_FACTOR> taskGroup{};
+
+    if (count == 0)
+    {
+        return taskGroup;
+    }
+
+    using CallableT = std::decay_t<TFunc>;
+    CallableT callable{ std::forward<TFunc>(func) };
+
+    if (!parallel || count == 1)
+    {
+        for (U32 index = 0; index < count; ++index)
+        {
+            std::invoke(callable, index);
+        }
+
+        return taskGroup;
+    }
+
+    U32 const parallelFactor = DRE::Max<U32>(1, DRE::Min<U32>(MAX_PARALLEL_FACTOR, count));
+    U32 const effectiveChunkSize = chunkSize != 0 ? chunkSize : ((count + parallelFactor - 1) / parallelFactor);
+
+    for (U32 chunkID = 0; chunkID < parallelFactor; ++chunkID)
+    {
+        taskGroup.Add(std::async(std::launch::async, [chunkID, effectiveChunkSize, count, callable]() mutable
+        {
+            U32 const chunkStart = chunkID * effectiveChunkSize;
+            if (chunkStart >= count)
+            {
+                return;
+            }
+
+            U32 const chunkEnd = DRE::Min<U32>(chunkStart + effectiveChunkSize, count);
+            for (U32 index = chunkStart; index < chunkEnd; ++index)
+            {
+                std::invoke(callable, index);
+            }
+        }));
+    }
+
+    return taskGroup;
+}
+
+DRE_END_NAMESPACE
+

--- a/shaders/ambient_occlusion.comp
+++ b/shaders/ambient_occlusion.comp
@@ -147,7 +147,7 @@ void main(uint3 DTid : SV_DispatchThreadID)
         // reintroduce lost luminance!
 
         ao_output[coords] = visibility;
-        DEBUG_TEXTURE[coords] = float4(normalWS, 1);
+        //DEBUG_TEXTURE[coords] = float4(normalWS, 1);
         //ao_output[coords] = float(coords.x) / GetViewportSize().x;
     }
     else

--- a/shaders/gbuffer_pbr.frag
+++ b/shaders/gbuffer_pbr.frag
@@ -19,7 +19,10 @@ struct GBuffer
     float4 Normal_Metalness     : SV_Target1;
     float2 Velocity             : SV_Target2;
     float4 ObjectID             : SV_Target3;
+
+    float4 DEBUG_TEXTURE        : SV_Target4;
 };
+
 
 [require(spvRayQueryKHR)]
 [shader("pixel")]
@@ -37,5 +40,9 @@ GBuffer main(PSInput input)
     Output.Velocity = CalculateVelocity(input.ndc_pos, input.prev_wpos);
     Output.ObjectID = GlobalID2Color();
 
+    //Output.DEBUG_TEXTURE = float4(input.TBN[2], 1);
+    //Output.DEBUG_TEXTURE = float4(frac(input.uv), 0, 1);
+    Output.DEBUG_TEXTURE = float4(MaterialProperties.metalness.rrr, 1);
+    
     return Output;
 }

--- a/src/engine/io/IOManager.cpp
+++ b/src/engine/io/IOManager.cpp
@@ -159,10 +159,10 @@ void IOManager::ParseMaterialTexture_Parallel(aiScene const* scene, aiMaterial c
 
         Data::Texture2D dataTexture = ReadTexture2D(textureFilePath.GetData(), channels);
         GFX::Texture* gfxTexture = nullptr;
-        
+
         {
             std::lock_guard<std::mutex> guard{ m_TextureLoadingMutex };
-            GFX::g_GraphicsManager->GetTextureBank().LoadTexture2DSync(
+            gfxTexture = GFX::g_GraphicsManager->GetTextureBank().LoadTexture2DSync(
                 dataTexture.GetName(),
                 dataTexture.GetSizeX(),
                 dataTexture.GetSizeY(),
@@ -262,6 +262,7 @@ void IOManager::ParseAssimpMaterials(aiScene const* scene, char const* sceneName
     [this, scene, sceneName, metalnessRoughnessOverride, &textureFilePath, &materialMutex](DRE::U32 index)
     {
         aiMaterial const* aiMat = scene->mMaterials[index];
+
         Data::Material* material = nullptr;
         {
             std::lock_guard<std::mutex> guard{ materialMutex };
@@ -345,24 +346,5 @@ void IOManager::ParseAssimpMeshes(VKW::Context& gfxContext, aiScene const* scene
         GFX::g_GraphicsManager->GetRayTracignManager().RegisterGeometry(m_GeometryLibrary->GetGeometry(i, sceneName), gfxContext);
     }
 }
-
-//
-//void IOManager::LoadShaderBinaries()
-//{
-//    std::filesystem::recursive_directory_iterator dir_iterator{ "shaders", std::filesystem::directory_options::follow_directory_symlink };
-//
-//    for (auto const& entry : dir_iterator)
-//    {
-//        if (entry.path().has_extension() && entry.path().extension() == ".spv")
-//        {
-//            DRE::ByteBuffer moduleBuffer{ static_cast<std::uint64_t>(entry.file_size()) };
-//            ReadFileToBuffer(entry.path().generic_string().c_str(), &moduleBuffer);
-//
-//            
-//        }
-//    }
-//
-//    m_ShaderObserverThread = std::thread{ &IOManager::ShaderObserver, this };
-//}
 
 }

--- a/src/engine/io/IOManager.cpp
+++ b/src/engine/io/IOManager.cpp
@@ -13,6 +13,7 @@
 #include <foundation\Container\HashTable.hpp>
 #include <foundation\system\Time.hpp>
 #include <foundation\util\Hash.hpp>
+#include <foundation\system\Parallel.hpp>
 
 #include <assimp\Importer.hpp>
 #include <assimp\postprocess.h>
@@ -119,7 +120,7 @@ Data::Texture2D IOManager::ReadTexture2D(char const* path, Data::TextureChannelV
     return texture;
 }
 
-void IOManager::ParseMaterialTexture(aiScene const* scene, aiMaterial const* aiMat, DRE::String256 const& assetFolderPath, Data::Material* material, Data::Material::TextureProperty::Slot slot, Data::TextureChannelVariations channels)
+void IOManager::ParseMaterialTexture_Parallel(aiScene const* scene, aiMaterial const* aiMat, DRE::String256 const& assetFolderPath, Data::Material* material, Data::Material::TextureProperty::Slot slot, Data::TextureChannelVariations channels)
 {
     aiString aiTexturePath;
     aiTextureType aiType = aiTextureType_NONE;
@@ -157,13 +158,18 @@ void IOManager::ParseMaterialTexture(aiScene const* scene, aiMaterial const* aiM
         textureFilePath.Append(aiTexturePath.C_Str(), DRE::U16(aiTexturePath.length));
 
         Data::Texture2D dataTexture = ReadTexture2D(textureFilePath.GetData(), channels);
-        GFX::Texture* gfxTexture = GFX::g_GraphicsManager->GetTextureBank().LoadTexture2DSync(
-            dataTexture.GetName(),
-            dataTexture.GetSizeX(),
-            dataTexture.GetSizeY(),
-            dataTexture.GetFormat(),
-            dataTexture.GetBuffer()
-        );
+        GFX::Texture* gfxTexture = nullptr;
+        
+        {
+            std::lock_guard<std::mutex> guard{ m_TextureLoadingMutex };
+            GFX::g_GraphicsManager->GetTextureBank().LoadTexture2DSync(
+                dataTexture.GetName(),
+                dataTexture.GetSizeX(),
+                dataTexture.GetSizeY(),
+                dataTexture.GetFormat(),
+                dataTexture.GetBuffer()
+            );
+        }
 
         material->AssignTextureToSlot(slot, DRE_MOVE(dataTexture), gfxTexture);
     }
@@ -216,7 +222,7 @@ WORLD::SceneNode* IOManager::ParseModelFile(char const* path, WORLD::Scene& targ
 {
     Assimp::Importer importer = Assimp::Importer();
 
-    aiScene const* scene = importer.ReadFile(path, aiProcessPreset_TargetRealtime_Fast | aiProcess_FlipUVs);
+    aiScene const* scene = importer.ReadFile(path, aiProcessPreset_TargetRealtime_Fast);
     char const* sceneName = aiScene::GetShortFilename(path);
 
     DRE_ASSERT(scene != nullptr, "Failed to load a model file.");
@@ -250,10 +256,17 @@ void IOManager::ParseAssimpMaterials(aiScene const* scene, char const* sceneName
     }
     textureFilePath.Shrink(folderEnd);
 
-    for (std::uint32_t i = 0, size = scene->mNumMaterials; i < size; i++)
+    std::mutex materialMutex;
+
+    DRE::ParallelFor<16>(scene->mNumMaterials, 
+    [this, scene, sceneName, metalnessRoughnessOverride, &textureFilePath, &materialMutex](DRE::U32 index)
     {
-        aiMaterial* aiMat = scene->mMaterials[i];
-        Data::Material* material = m_MaterialLibrary->CreateMaterial(i, sceneName, aiMat->GetName().C_Str());
+        aiMaterial const* aiMat = scene->mMaterials[index];
+        Data::Material* material = nullptr;
+        {
+            std::lock_guard<std::mutex> guard{ materialMutex };
+            material = m_MaterialLibrary->CreateMaterial(index, sceneName, aiMat->GetName().C_Str());
+        }
 
         DRE_ASSERT(aiMat->GetTextureCount(aiTextureType_DIFFUSE) <= 1, "We don't support multiple textures of the same type per material (DIFFUSE).");
         DRE_ASSERT(aiMat->GetTextureCount(aiTextureType_NORMALS) <= 1, "We don't support multiple textures of the same type per material (NORMALS)");
@@ -262,26 +275,30 @@ void IOManager::ParseAssimpMaterials(aiScene const* scene, char const* sceneName
         DRE_ASSERT(aiMat->GetTextureCount(aiTextureType_AMBIENT_OCCLUSION) <= 1, "We don't support multiple textures of the same type per material (AMBIENT_OCCLUSION)");
 
         // PROCESS TEXTURES
-        ParseMaterialTexture(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::DIFFUSE, Data::TEXTURE_VARIATION_RGBA);
-        ParseMaterialTexture(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::NORMAL, Data::TEXTURE_VARIATION_RGBA);
+        ParseMaterialTexture_Parallel(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::DIFFUSE, Data::TEXTURE_VARIATION_RGBA);
+        ParseMaterialTexture_Parallel(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::NORMAL, Data::TEXTURE_VARIATION_RGBA);
 
         if (metalnessRoughnessOverride == Data::TEXTURE_VARIATION_INVALID)
         {
-            ParseMaterialTexture(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::METALNESS, Data::TEXTURE_VARIATION_GRAY);
-            ParseMaterialTexture(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::ROUGHNESS, Data::TEXTURE_VARIATION_GRAY);
+            ParseMaterialTexture_Parallel(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::METALNESS, Data::TEXTURE_VARIATION_GRAY);
+            ParseMaterialTexture_Parallel(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::ROUGHNESS, Data::TEXTURE_VARIATION_GRAY);
         }
         else
         {
             // it means we have texture with merged metalness and roughness attributes. Let it lie in metalness
-            ParseMaterialTexture(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::METALNESS, metalnessRoughnessOverride);
+            ParseMaterialTexture_Parallel(scene, aiMat, textureFilePath, material, Data::Material::TextureProperty::METALNESS, metalnessRoughnessOverride);
         }
         // TODO: load rgb here
 
         material->GetRenderingProperties().SetMaterialType(Data::Material::RenderingProperties::MATERIAL_TYPE_OPAQUE);
 
-        GFX::Material* gfxMaterial = GFX::g_GraphicsManager->GetPipelineDB().CreateMaterial(material->GetName(), material->GetRenderingProperties().GetMaterialType());
-        material->FlushToGfxMaterial(gfxMaterial);
+        {
+            std::lock_guard<std::mutex> guard{ materialMutex };
+            GFX::Material* gfxMaterial = GFX::g_GraphicsManager->GetPipelineDB().CreateMaterial(material->GetName(), material->GetRenderingProperties().GetMaterialType());
+            material->FlushToGfxMaterial(gfxMaterial);
+        }
     }
+    , true);
 }
 
 void IOManager::ParseAssimpMeshes(VKW::Context& gfxContext, aiScene const* scene, char const* sceneName)

--- a/src/engine/io/ShaderDBImpl.cpp
+++ b/src/engine/io/ShaderDBImpl.cpp
@@ -4,10 +4,10 @@
 #include <engine\io\ShaderDB.hpp>
 
 #include <engine\io\IOManager.hpp>
-#include <foundation/system/Parallel.hpp>
+#include <foundation\system\Parallel.hpp>
 
 #include <spirv_cross.hpp>
-#include <wrl/client.h>
+#include <wrl\client.h>
 #include <dxcapi.h>
 
 #include <slang.h>

--- a/src/engine/io/ShaderDBImpl.cpp
+++ b/src/engine/io/ShaderDBImpl.cpp
@@ -4,6 +4,7 @@
 #include <engine\io\ShaderDB.hpp>
 
 #include <engine\io\IOManager.hpp>
+#include <foundation/system/Parallel.hpp>
 
 #include <spirv_cross.hpp>
 #include <wrl/client.h>
@@ -500,32 +501,14 @@ void ShaderDBImpl::CompileSources(bool parallel)
         }
     }
 
-    std::uint32_t constexpr MAX_PARALLEL_FACTOR = 8;
-    std::uint32_t const parallelFactor = parallel ? MAX_PARALLEL_FACTOR : 1;
-    std::uint32_t const parallelChunkSize = fileNames.Size() / parallelFactor + 1;
+    auto compileTasks = DRE::ParallelFor<8>(fileNames.Size(), [this, &fileNames](DRE::U32 index)
+        {
+            DRE::String64& name = fileNames[index].name;
+            DRE::ByteBuffer spirv = CompileShader(name.GetData(), fileNames[index].type);
+            DRE_ASSERT(spirv.Size() > 0, "Can't run with invalid shader.");
+        }, parallel);
 
-    DRE::InplaceVector<std::future<void>, MAX_PARALLEL_FACTOR> parallelCompilations;
-    for (std::uint32_t i = 0; i < parallelFactor; i++)
-    {
-        parallelCompilations.EmplaceBack(std::async(std::launch::async, [parallelChunkSize, &parallelCompilations, &fileNames, this](std::uint32_t chunkID) 
-            {
-                std::uint32_t chunkStart = chunkID * parallelChunkSize;
-                std::uint32_t chunkEnd = DRE::Min((chunkID + 1) * parallelChunkSize, fileNames.Size());
-
-                for (std::uint32_t j = chunkStart; j < chunkEnd; j++)
-                {
-                    DRE::String64& name = fileNames[j].name;
-                    DRE::ByteBuffer spirv = CompileShader(name.GetData(), fileNames[j].type);
-                    DRE_ASSERT(spirv.Size() > 0, "Can't run with invalid shader.");
-                }
-            }, i));
-    }
-
-    // std::wait_all not available yet/experimental. Though we should be fine
-    for (std::uint32_t i = 0; i < parallelFactor; i++)
-    {
-        parallelCompilations[i].wait();
-    }
+    compileTasks.Wait();
 }
 
 DRE::InplaceVector<DRE::String64, 12> ShaderDBImpl::GetPendingShaders()

--- a/src/foundation/CMakeLists.txt
+++ b/src/foundation/CMakeLists.txt
@@ -33,6 +33,7 @@ set(FOUNDATION_HEADER_LIST
 	"${DRE_SOURCE_DIR}/include/foundation/string/InplaceString.hpp"
 	"${DRE_SOURCE_DIR}/include/foundation/string/StringUtil.hpp"
 	"${DRE_SOURCE_DIR}/include/foundation/system/DynamicLibrary.hpp"
+	"${DRE_SOURCE_DIR}/include/foundation/system/Parallel.hpp"
 	"${DRE_SOURCE_DIR}/include/foundation/system/Time.hpp"
 	"${DRE_SOURCE_DIR}/include/foundation/system/Window.hpp"
 	"${DRE_SOURCE_DIR}/include/foundation/util/AlignedStorage.hpp"

--- a/src/gfx/pass/GBufferPass.cpp
+++ b/src/gfx/pass/GBufferPass.cpp
@@ -44,6 +44,11 @@ void GBufferPass::RegisterResources(RenderGraph& graph)
         gBufferFormats[3], renderWidth, renderHeight,
         3);
 
+    graph.RegisterRenderTarget(this,
+        RESOURCE_ID(TextureID::DEBUG_TEXTURE),
+        VKW::FORMAT_R32G32B32A32_FLOAT, renderWidth, renderHeight,
+        4);
+
     graph.RegisterDepthOnlyTarget(this,
         RESOURCE_ID(TextureID::MainDepth),
         g_GraphicsManager->GetMainDepthFormat(), renderWidth, renderHeight);
@@ -64,16 +69,18 @@ void GBufferPass::Render(RenderGraph& graph, VKW::Context& context)
     VKW::ImageResourceView* attachmentB = graph.GetTexture(RESOURCE_ID(TextureID::GBufferB_NormalMetalness))->GetShaderView();
     VKW::ImageResourceView* attachmentC = graph.GetTexture(RESOURCE_ID(TextureID::GBufferC_Velocity))->GetShaderView();
     VKW::ImageResourceView* attachmentD = graph.GetTexture(RESOURCE_ID(TextureID::GBufferD_ObjectIDBuffer))->GetShaderView();
+    VKW::ImageResourceView* attachmentDEBUG = graph.GetTexture(RESOURCE_ID(TextureID::DEBUG_TEXTURE))->GetShaderView();
     VKW::ImageResourceView* depthAttachment = graph.GetTexture(RESOURCE_ID(TextureID::MainDepth))->GetShaderView();
 
     g_GraphicsManager->GetDependencyManager().ResourceBarrier(context, attachmentA->parentResource_, VKW::RESOURCE_ACCESS_COLOR_ATTACHMENT, VKW::STAGE_COLOR_OUTPUT);
     g_GraphicsManager->GetDependencyManager().ResourceBarrier(context, attachmentB->parentResource_, VKW::RESOURCE_ACCESS_COLOR_ATTACHMENT, VKW::STAGE_COLOR_OUTPUT);
     g_GraphicsManager->GetDependencyManager().ResourceBarrier(context, attachmentC->parentResource_, VKW::RESOURCE_ACCESS_COLOR_ATTACHMENT, VKW::STAGE_COLOR_OUTPUT);
     g_GraphicsManager->GetDependencyManager().ResourceBarrier(context, attachmentD->parentResource_, VKW::RESOURCE_ACCESS_COLOR_ATTACHMENT, VKW::STAGE_COLOR_OUTPUT);
+    g_GraphicsManager->GetDependencyManager().ResourceBarrier(context, attachmentDEBUG->parentResource_, VKW::RESOURCE_ACCESS_COLOR_ATTACHMENT, VKW::STAGE_COLOR_OUTPUT);
     g_GraphicsManager->GetDependencyManager().ResourceBarrier(context, depthAttachment->parentResource_, VKW::RESOURCE_ACCESS_DEPTH_ONLY_ATTACHMENT, VKW::STAGE_ALL_GRAPHICS);
 
-    std::uint32_t constexpr attachmentsCount = 4;
-    VKW::ImageResourceView* attachments[attachmentsCount] = { attachmentA, attachmentB, attachmentC, attachmentD };
+    std::uint32_t constexpr attachmentsCount = 5;
+    VKW::ImageResourceView* attachments[attachmentsCount] = { attachmentA, attachmentB, attachmentC, attachmentD, attachmentDEBUG };
 
     //VKW::PipelineLayout* passLayout = graph.GetPassPipelineLayout(GetID());
     VKW::PipelineLayout* passLayout = g_GraphicsManager->GetMainDevice()->GetDescriptorManager()->GetGlobalPipelineLayout();

--- a/src/gfx/pipeline/PipelineDB.cpp
+++ b/src/gfx/pipeline/PipelineDB.cpp
@@ -163,6 +163,7 @@ DRE::String64 const* PipelineDB::CreateGraphicsGBufferPipeline(char const* name)
     desc.AddColorOutput(gBufferFormats[1]); // normal_metalness
     desc.AddColorOutput(gBufferFormats[2]); // velocity
     desc.AddColorOutput(gBufferFormats[3]); // objectID
+    desc.AddColorOutput(VKW::FORMAT_R32G32B32A32_FLOAT); // DEBUG_TEXTURE
 
     AddDREVertexAttributes(desc);
 


### PR DESCRIPTION
## Summary
- revert the foundation header list additions back to tab-indented entries to match surrounding style

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133c4e76c4832f99032ca145633768)